### PR TITLE
feat: add coding test entry form page

### DIFF
--- a/app/coding-test/page.tsx
+++ b/app/coding-test/page.tsx
@@ -1,0 +1,317 @@
+'use client'
+
+import { useState } from 'react'
+
+interface FormData {
+  name: string
+  email: string
+  phone: string
+  experience: string
+  skills: string[]
+  availability: string
+  message: string
+}
+
+const skillOptions = [
+  'JavaScript',
+  'TypeScript',
+  'React',
+  'Next.js',
+  'Node.js',
+  'Python',
+  'PHP',
+  'Java',
+  'SQL',
+  'MongoDB',
+  'AWS',
+  'Docker',
+  'Git'
+]
+
+export default function CodingTestPage() {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    email: '',
+    phone: '',
+    experience: '',
+    skills: [],
+    availability: '',
+    message: ''
+  })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }))
+  }
+
+  const handleSkillToggle = (skill: string) => {
+    setFormData(prev => ({
+      ...prev,
+      skills: prev.skills.includes(skill)
+        ? prev.skills.filter(s => s !== skill)
+        : [...prev.skills, skill]
+    }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+
+    // Simulate API call
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    setIsSubmitting(false)
+    setIsSubmitted(true)
+  }
+
+  if (isSubmitted) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full text-center">
+          <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">送信完了！</h2>
+          <p className="text-gray-600 mb-6">
+            エントリーが正常に送信されました。<br />
+            担当者より近日中にご連絡いたします。
+          </p>
+          <button
+            onClick={() => {
+              setIsSubmitted(false)
+              setFormData({
+                name: '',
+                email: '',
+                phone: '',
+                experience: '',
+                skills: [],
+                availability: '',
+                message: ''
+              })
+            }}
+            className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            新規エントリー
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-2xl shadow-xl overflow-hidden">
+          {/* Header */}
+          <div className="bg-gradient-to-r from-blue-600 to-indigo-600 px-8 py-6">
+            <h1 className="text-3xl font-bold text-white mb-2">
+              開発者エントリーフォーム
+            </h1>
+            <p className="text-blue-100">
+              あなたのスキルと経験を教えてください
+            </p>
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="p-8 space-y-6">
+            {/* Personal Information */}
+            <div className="space-y-4">
+              <h2 className="text-xl font-semibold text-gray-900 pb-2 border-b border-gray-200">
+                基本情報
+              </h2>
+              
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+                    お名前 *
+                  </label>
+                  <input
+                    type="text"
+                    id="name"
+                    name="name"
+                    value={formData.name}
+                    onChange={handleInputChange}
+                    required
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                    placeholder="山田 太郎"
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                    メールアドレス *
+                  </label>
+                  <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    value={formData.email}
+                    onChange={handleInputChange}
+                    required
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                    placeholder="example@email.com"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-2">
+                  電話番号
+                </label>
+                <input
+                  type="tel"
+                  id="phone"
+                  name="phone"
+                  value={formData.phone}
+                  onChange={handleInputChange}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                  placeholder="090-1234-5678"
+                />
+              </div>
+            </div>
+
+            {/* Experience */}
+            <div className="space-y-4">
+              <h2 className="text-xl font-semibold text-gray-900 pb-2 border-b border-gray-200">
+                経験・スキル
+              </h2>
+
+              <div>
+                <label htmlFor="experience" className="block text-sm font-medium text-gray-700 mb-2">
+                  開発経験 *
+                </label>
+                <select
+                  id="experience"
+                  name="experience"
+                  value={formData.experience}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                >
+                  <option value="">選択してください</option>
+                  <option value="未経験">未経験</option>
+                  <option value="1年未満">1年未満</option>
+                  <option value="1-3年">1-3年</option>
+                  <option value="3-5年">3-5年</option>
+                  <option value="5年以上">5年以上</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-3">
+                  得意な技術スタック（複数選択可）
+                </label>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                  {skillOptions.map((skill) => (
+                    <label
+                      key={skill}
+                      className={`flex items-center p-3 border rounded-lg cursor-pointer transition-all ${
+                        formData.skills.includes(skill)
+                          ? 'bg-blue-50 border-blue-300 text-blue-700'
+                          : 'bg-white border-gray-300 hover:border-gray-400'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={formData.skills.includes(skill)}
+                        onChange={() => handleSkillToggle(skill)}
+                        className="sr-only"
+                      />
+                      <div className={`w-4 h-4 mr-3 rounded border-2 flex items-center justify-center ${
+                        formData.skills.includes(skill)
+                          ? 'bg-blue-600 border-blue-600'
+                          : 'border-gray-300'
+                      }`}>
+                        {formData.skills.includes(skill) && (
+                          <svg className="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                          </svg>
+                        )}
+                      </div>
+                      <span className="text-sm font-medium">{skill}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Availability */}
+            <div className="space-y-4">
+              <h2 className="text-xl font-semibold text-gray-900 pb-2 border-b border-gray-200">
+                勤務について
+              </h2>
+
+              <div>
+                <label htmlFor="availability" className="block text-sm font-medium text-gray-700 mb-2">
+                  希望勤務形態 *
+                </label>
+                <select
+                  id="availability"
+                  name="availability"
+                  value={formData.availability}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                >
+                  <option value="">選択してください</option>
+                  <option value="フルタイム">フルタイム</option>
+                  <option value="パートタイム">パートタイム</option>
+                  <option value="フリーランス">フリーランス</option>
+                  <option value="インターン">インターン</option>
+                  <option value="リモートワーク">リモートワーク</option>
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-2">
+                  自己PR・メッセージ
+                </label>
+                <textarea
+                  id="message"
+                  name="message"
+                  value={formData.message}
+                  onChange={handleInputChange}
+                  rows={4}
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all resize-none"
+                  placeholder="あなたの強みや目標について教えてください..."
+                />
+              </div>
+            </div>
+
+            {/* Submit Button */}
+            <div className="pt-6">
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className={`w-full py-4 px-6 rounded-lg font-semibold text-lg transition-all ${
+                  isSubmitting
+                    ? 'bg-gray-400 text-gray-700 cursor-not-allowed'
+                    : 'bg-gradient-to-r from-blue-600 to-indigo-600 text-white hover:from-blue-700 hover:to-indigo-700 transform hover:scale-[1.02]'
+                } shadow-lg`}
+              >
+                {isSubmitting ? (
+                  <div className="flex items-center justify-center">
+                    <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                    送信中...
+                  </div>
+                ) : (
+                  'エントリーを送信'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a comprehensive developer entry form page at /coding-test

## Features
- Modern responsive design with gradient background
- Multi-section form with personal info, skills, and work preferences
- Interactive skill selection with custom checkboxes
- Form validation and submission states
- Success screen with feedback
- Mobile-first responsive design
- Follows existing project design patterns

Closes #12

Generated with [Claude Code](https://claude.ai/code)