### PR TITLE
fix: remove invalid textFillColor CSS property

### DIFF
--- a/app/scrum/page.tsx
+++ b/app/scrum/page.tsx
@@ -155,8 +155,7 @@ export default function ScrumManagement() {
             background: 'linear-gradient(135deg, #667eea, #764ba2)',
             backgroundClip: 'text',
             WebkitBackgroundClip: 'text',
-            WebkitTextFillColor: 'transparent',
-            textFillColor: 'transparent'
+            WebkitTextFillColor: 'transparent'
           }}>
             スクラム開発管理ツール
           </h1>


### PR DESCRIPTION
Fix TypeScript compilation error in scrum page

Removed invalid `textFillColor: 'transparent'` CSS property that was causing build failure. The gradient text effect continues to work correctly using the webkit-specific `WebkitTextFillColor` property.

Closes #14

Generated with [Claude Code](https://claude.ai/code)