### PR TITLE
fix: remove invalid textFillColor CSS properties

### DIFF
--- a/app/scrum/page.tsx
+++ b/app/scrum/page.tsx
@@ -155,8 +155,7 @@ export default function ScrumManagement() {
             background: 'linear-gradient(135deg, #667eea, #764ba2)',
             backgroundClip: 'text',
             WebkitBackgroundClip: 'text',
-            WebkitTextFillColor: 'transparent',
-            textFillColor: 'transparent'
+            WebkitTextFillColor: 'transparent'
           }}>
             スクラム開発管理ツール
           </h1>
@@ -277,8 +276,7 @@ export default function ScrumManagement() {
                 background: 'linear-gradient(135deg, #667eea, #764ba2)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                textFillColor: 'transparent'
+                WebkitTextFillColor: 'transparent'
               }}>
                 プロダクトバックログ
               </h2>
@@ -649,8 +647,7 @@ export default function ScrumManagement() {
                 background: 'linear-gradient(135deg, #667eea, #764ba2)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                textFillColor: 'transparent'
+                WebkitTextFillColor: 'transparent'
               }}>
                 デイリースタンドアップ
               </h2>
@@ -941,8 +938,7 @@ export default function ScrumManagement() {
                 background: 'linear-gradient(135deg, #667eea, #764ba2)',
                 backgroundClip: 'text',
                 WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                textFillColor: 'transparent'
+                WebkitTextFillColor: 'transparent'
               }}>
                 スプリント振り返り
               </h2>


### PR DESCRIPTION
Fix TypeScript compilation error in scrum page

Removed all instances of invalid `textFillColor: 'transparent'` CSS property that were causing build failure. The gradient text effect continues to work correctly using the webkit-specific `WebkitTextFillColor` property.

Fixes 4 instances:
- Main header title
- Backlog section header
- Daily standup section header
- Retrospective section header

Closes #14

Generated with [Claude Code](https://claude.ai/code)